### PR TITLE
Default build activations to false

### DIFF
--- a/src/main/java/com/palantir/stash/stashbot/config/ConfigurationPersistenceImpl.java
+++ b/src/main/java/com/palantir/stash/stashbot/config/ConfigurationPersistenceImpl.java
@@ -209,10 +209,10 @@ public class ConfigurationPersistenceImpl implements ConfigurationPersistenceSer
                 RepositoryConfiguration.class,
                 new DBParam("REPO_ID", repo.getId()));
             rc.save();
-            // default the 3 base job types to enabled
-            setJobTypeStatusMapping(rc, JobType.VERIFY_COMMIT, true);
-            setJobTypeStatusMapping(rc, JobType.VERIFY_PR, true);
-            setJobTypeStatusMapping(rc, JobType.PUBLISH, true);
+            // default the 3 base job types to disabled
+            setJobTypeStatusMapping(rc, JobType.VERIFY_COMMIT, false);
+            setJobTypeStatusMapping(rc, JobType.VERIFY_PR, false);
+            setJobTypeStatusMapping(rc, JobType.PUBLISH, false);
             return rc;
         }
         return repos[0];

--- a/src/main/java/com/palantir/stash/stashbot/persistence/JobTypeStatusMapping.java
+++ b/src/main/java/com/palantir/stash/stashbot/persistence/JobTypeStatusMapping.java
@@ -39,7 +39,9 @@ public interface JobTypeStatusMapping extends Entity {
 
     @Accessor("IS_ENABLED")
     @NotNull
-    @Default("true")
+    // not actually honored on automatically vivified objects; see
+    // com.palantir.stash.stashbot.config.ConfigurationPersistenceImpl.RepositoryConfiguration
+    @Default("false")
     public Boolean getIsEnabled();
 
     @Mutator("IS_ENABLED")


### PR DESCRIPTION
First Do No Harm: require users to activate each build type they want.

This will hopefully prevent people from accidentally, say, activating publish builds on fork repos.
