### PR TITLE
set default refspec for verify builds to support cross-repo PRs

### DIFF
--- a/src/main/resources/jenkins-verify-job.vm
+++ b/src/main/resources/jenkins-verify-job.vm
@@ -52,7 +52,7 @@
       <hudson.plugins.git.UserRemoteConfig>
         <url>$esc.xml($repositoryUrl)</url>
         <name>origin</name>
-        <refspec></refspec>
+        <refspec>+refs/pull-requests/*:refs/remotes/origin/pull-requests/* +refs/heads/*:refs/remotes/origin/*</refspec>
 #if ( $credentialUUID )
         <credentialsId>$credentialUUID</credentialsId>
 #end


### PR DESCRIPTION
This should resolve https://github.com/terabyte/stashbot/issues/19

When the FROM side of a pull request is a different repo than the TO side, manual triggers of the verification build will fail unless the verify build is able to see branches under refs/pull-requests/*
