### PR TITLE
fix generation of links to prefixed/foldered jobs

### DIFF
--- a/src/main/java/com/palantir/stash/stashbot/servlet/BuildSuccessReportingServlet.java
+++ b/src/main/java/com/palantir/stash/stashbot/servlet/BuildSuccessReportingServlet.java
@@ -339,7 +339,7 @@ public class BuildSuccessReportingServlet extends HttpServlet {
         }
         String url = baseUrl;
         if (!prefix.isEmpty()) {
-            url = url + "/job/" + StringUtils.join(prefix.split("/"), "/job.");
+            url = url + StringUtils.join(prefix.split("/"), "/job/");
         }
         url = url + "/job/" + jt.getBuildNameFor(repo) + "/" + String.valueOf(buildNumber);
         return url;


### PR DESCRIPTION
`http://jenkins/job//job.stashbot/job.test/job.testrepo/job/test_testrepo_verify_pr/2` is not a working link. :)

`http://jenkins/job/stashbot/job/test/job/testrepo/job/test_testrepo_verification/4` is! :)
