### PR TITLE
workaround for upstream plugin bug

### DIFF
--- a/src/main/resources/jenkins-publish-job.vm
+++ b/src/main/resources/jenkins-publish-job.vm
@@ -147,7 +147,7 @@
             </hudson.plugins.postbuildtask.LogProperties>
           </logTexts>
           <EscalateStatus>false</EscalateStatus>
-          <RunIfJobSuccessful>true</RunIfJobSuccessful>
+          <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>$esc.xml($successCommand)</script>
         </hudson.plugins.postbuildtask.TaskProperties>
         <hudson.plugins.postbuildtask.TaskProperties>

--- a/src/main/resources/jenkins-verify-job.vm
+++ b/src/main/resources/jenkins-verify-job.vm
@@ -146,7 +146,7 @@
             </hudson.plugins.postbuildtask.LogProperties>
           </logTexts>
           <EscalateStatus>false</EscalateStatus>
-          <RunIfJobSuccessful>true</RunIfJobSuccessful>
+          <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>$esc.xml($successCommand)</script>
         </hudson.plugins.postbuildtask.TaskProperties>
         <hudson.plugins.postbuildtask.TaskProperties>

--- a/src/main/resources/jenkins-verify-pull-request-job.vm
+++ b/src/main/resources/jenkins-verify-pull-request-job.vm
@@ -173,7 +173,7 @@
             </hudson.plugins.postbuildtask.LogProperties>
           </logTexts>
           <EscalateStatus>false</EscalateStatus>
-          <RunIfJobSuccessful>true</RunIfJobSuccessful>
+          <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>$esc.xml($successCommand)</script>
         </hudson.plugins.postbuildtask.TaskProperties>
         <hudson.plugins.postbuildtask.TaskProperties>


### PR DESCRIPTION
Per https://issues.jenkins-ci.org/browse/JENKINS-12303, there is
a UI bug with the jenkins post-build task plugin: if you configure more
than one post-build script task with non-matching values of the
RunIfJobSuccessful checkbox, only the first of the script tasks
will actually be saved when you commit the config update.

The stashbot normally works around this bug by posting the (completely
valid) XML configuration directly to the jenkins REST API, but if the
user has clicked "Preserve jenkins job config" in the stashbot ui and
then makes any jenkins-side change that touches the post-build actions
stage (for example adding additional test coverage reporting, e.g.
cobertura artifact publishing) the "BUILD FAILURE1" task suddenly
vanishes, to the intense annoyance and confusion of all.

Unfortunately, the "post-build actions" plugin is currently abandoned
and unsupported, and the above-referenced bug has been open since 2012.

Luckily, we can work around the bug: there is actually no need for
RunIfJobSuccessful to be set to "true" for either of stashbot's
post-build action tasks.  The actual gating logic is the log string
matcher for `BUILD SUCCESS0` or `BUILD FAILURE1`: the task will not
actually fire unless those strings are found in the logs.
